### PR TITLE
Add eups, pybind11 binding, and kernel minimum height

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# Kernel-Based Hough Transform for Detecting Straight Lines in Images
+# Kernel-Based Hough Transform for Detecting Straight Lines in Images for the LSST Stack
 
-This repository contains the reference implementation of the Kernel-Based Hough Transform (KHT). The KHT is a real-time line detection procedure that extends the conventional voting procedure of the [Hough transform](https://en.wikipedia.org/wiki/Hough_transform). It operates on clusters of approximately collinear pixels. For each cluster, the KHT casts votes using an oriented elliptical-Gaussian kernel that models the uncertainty associated with the best-fitting line for the corresponding cluster. The proposed approach not only significantly improves the performance of the voting scheme, but also produces a much cleaner voting map and makes the transform more robust to the detection of spurious lines.
+This is the LSST stack code fork of the [KHT package](https://github.com/laffernandes/kht). Please see [Fernandes and Oliveira, 2008](http://www.ic.uff.br/~laffernandes/content/publications/journal/2008_pr_41(1)/fernandes_oliveira-pr-41(1)-2008-pre_print.pdf), for a full description of the algorithm.
 
-Please cite our Pattern Recognition paper if you use this code in your research:
-
+Please cite the original paper if you use this code in your research:
 ```{.bib}
 @Article{fernandes_oliveira-pr-41(1)-2008,
     author  = {Fernandes, Leandro A. F. and Oliveira, Manuel M.},
@@ -18,180 +17,22 @@ Please cite our Pattern Recognition paper if you use this code in your research:
 }
 ```
 
-The paper presents a complete description of the implemented technique. You will find additional material on the [project's page](http://www.ic.uff.br/~laffernandes/projects/kht).
 
-Please, let Leandro A. F. Fernandes ([laffernandes@ic.uff.br](mailto:laffernandes@ic.uff.br)) knows if you want to contribute to this project. Also, do not hesitate to contact him if you encounter any problems.
+This fork makes the following changes from the upstream package:
 
-**Contents:**
+* Building the package with eups is now supported.
+* A pybind11 python binding has been added as an alternative to the upstream boost python binding.
+* An optional argument has been added to the main `run_kht` function, which allows a cut to be made on the absolute value of the kernel height. A cut was already implemented for the minimum kernel height as a fraction of the maximum kernel height in an image. However, in cases where there was no real line in the image, the tallest kernel height is not a meaningful quantity and it is helpful to set an absolute value.
 
-1. [Requirements](#1-requirements)
-2. [How to Install KHT](#2-how-to-install-kht)
-3. [Compiling Examples](#3-compiling-examples)
-4. [Related Project](#4-related-project)
-5. [License](#5-license)
-6. [Releases](#6-releases)
+Using the Pybind11 Python Implementation
+----------------------------------------
+After building, the python module can be used as follows:
 
-## 1. Requirements
-
-Make sure that you have the following tools before attempting to use KHT.
-
-Required tool:
-
-- Your favorite [C++11](https://en.wikipedia.org/wiki/C%2B%2B11) compiler.
-- [CMake](https://cmake.org) (version >= 3.14) to automate installation and to build and run examples.
-
-Optional tool:
-
-- [Python](https://www.python.org) 2 or 3 interpreter, if you want to build and use KHT with Python.
-- [MATLAB](https://www.mathworks.com/products/matlab.html) (version >= R2007a), if you want to build and use KHT with MATLAB.
-- [Virtual enviroment](https://wiki.archlinux.org/index.php/Python/Virtual_environment) to create an isolated workspace for a Python application.
-
-The reference implementation of the KHT doesn't have any dependencies other than the [C++ standard library](https://en.cppreference.com/w/cpp/header). But some libraries are required if you want to use KHT with Python or build the sample Python and C++ applications.
-
-Required Python packages and C++ libraries, if you want to use KHT with Python:
-
-- [NumPy](https://numpy.org), the fundamental package for scientific computing with Python.
-- [Boost.Python](https://www.boost.org/doc/libs/release/libs/python/doc/html/index.html) (version >= 1.56), a C++ library which enables seamless interoperability between C++ and the Python programming language.
-- [Boost.NumPy](https://www.boost.org/doc/libs/release/libs/python/doc/html/numpy/index.html), a C++ library that extends Boost.Python to NumPy.
-
-Required C++ libraries and Python packages, if you want to build the C++ and Python sample application, respectively:
-
-- [OpenCV](https://opencv.org) (version >= 2.2), a C++ library of programming functions mainly aimed at real-time computer vision.
-- [OpenCV-Python](https://pypi.org/project/opencv-python), a wrapper package for OpenCV Python bindings.
-- [Matplotlib](https://matplotlib.org), a Python 2D plotting library which produces publication quality figures in a variety of hardcopy formats.
-
-## 2. How to Install KHT
-
-Use the [git clone](https://git-scm.com/docs/git-clone) command to download the project, where `<kht-dir>` must be replaced by the directory in which you want to place KHT's source code, or removed `<kht-dir>` from the command line to download the project to the `./kht` directory:
-
-```bash
-git clone https://github.com/laffernandes/kht.git <kht-dir>
 ```
+import lsst.kht
 
-The basic steps for configuring, building, and installing the KHT library look like this:
-
-```bash
-cd <kht-dir>/cpp
-mkdir build
-cd build
-cmake ..
-cmake --build . --config Release --target install
+lines = lsst.kht.find_satellites(image, clusterMinimumSize, clusterMinimumDeviation, 
+                                 delta, minimumKernelHeight, nSigmas, absMinimumKernelHeight)
 ```
+where the first six input parameters follow the conventions of the original [KHT](https://github.com/laffernandes/kht) and the last parameter `absMinimumKernelHeight` implements the absolute minimum kernel height cut described above.
 
-Notice that you may use the `-G <generator-name>` option of CMake's command-line tool to choose the build system (*e.g.*, Unix makefiles, Visual Studio, etc.). Please, refer to [CMake's Help](https://cmake.org/cmake/help/latest/manual/cmake.1.html) for a complete description of how to use the CMake's command-line tool.
-
-### Installing the Python Module
-
-We provide a back-end to access KHT from a Python environment. In order to make it available, you have to build the `kht` module, after installing the KHT library, using the commands presented bellow:
-
-```bash
-cd <kht-dir>/python
-mkdir build
-cd build
-cmake ..
-cmake --build . --config Release --target install
-```
-
-It is important to emphasize that both Python 2 and 3 are supported. Please, refer to [CMake's documentation](https://cmake.org/cmake/help/latest/module/FindPython.html) for details about how CMake finds the Python interpreter, compiler, and development environment.
-
-Finally, add `<cmake-install-prefix>/lib/kht/python/<python-version>` to the the `PYTHONPATH` environment variable. The `<cmake-install-prefix>` placeholder usually is `/usr/local` on Linux, and `C:/Program Files/KHT` or `C:/Program Files (x86)/KHT` on Windows. But it may change according to what was set in CMake. The `<python-version>` placeholder is the version of the Python interpreter found by CMake.
-
-Set the `PYTHONPATH` variable by calling following command in Linux:
-
-```bash
-export PYTHONPATH="$PYTHONPATH:<cmake-install-prefix>/lib/kht/python/<python-version>"
-```
-
-But this action is not permanent. The new value of `PYTHONPATH` will be lost as soon as you close the terminal. A possible solution to make an environment variable persistent for a user's environment is to export the variable from the user's profile script:
-
-  1. Open the current user's profile (the `~/.bash_profile` file) into a text editor.
-  2. Add the export command for the `PYTHONPATH` environment variable at the end of this file.
-  3. Save your changes.
-
-Execute the following steps to set the `PYTHONPATH` in Windows:
-
-  1. From the *Windows Explorer*, right click the *Computer* icon.
-  2. Choose *Properties* from the context menu.
-  3. Click the *Advanced system settings* link.
-  4. Click *Environment Variables*. In the section *System Variables*, find the `PYTHONPATH` environment variable and select it. Click *Edit*. If the `PYTHONPATH` environment variable does not exist, click *New*.
-  5. In the *Edit System Variable* (or *New System Variable*) window, specify the value of the `PYTHONPATH` environment variable to include `"<cmake-install-prefix>/lib/kht/python/<python-version>"`. Click *OK*. Close all remaining windows by clicking *OK*.
-  6. Reopen yout Python environment.
-
-## Installing the MATLAB Wrapper
-
-We provide a back-end to access KHT from MATLAB. In order to make it available, you have to build the MEX-file, after installing the KHT library, using the commands presented bellow:
-
-```bash
-cd <kht-dir>/matlab
-mkdir build
-cd build
-cmake ..
-cmake --build . --config Release --target install
-```
-
-Finally, open MATLAB and use the following commands to the instaled wrapper to MATLAB's search path:
-
-```matlab
-addpath('<cmake-install-prefix>/lib/kht/matlab')
-savepath
-```
-
-The `<cmake-install-prefix>` placeholder usually is `/usr/local` on Linux, and `C:/Program Files/KHT` or `C:/Program Files (x86)/KHT` on Windows. But it may change according to what was set in CMake.
-
-Sometimes CMake tells you that "Could NOT find Matlab (missing: Matlab_MEX_LIBRARY)" even when MATLAB is appropriately installed. In this case, you have to check whether the correct architecture (32- vs. 64-bit compiler) was selected for compiling the KHT library and its MATLAB wrapper. For instance, on Windows, instead of using CMake with the "Visual Studio 15 2017" generator, try to use the "Visual Studio 15 2017 Win64" generator and vice versa.
-
-## 3. Compiling Examples
-
-The basic steps for configuring and building the C++ example of the KHT look like this:
-
-```bash
-cd <kht-dir>/cpp/example
-mkdir build
-cd build
-cmake ..
-cmake --build . --config Release
-```
-
-Call `./main` to run the executable file produced on Linux, and `Release\main.exe` to run on Windows.
-
-Recall that `<kht-dir>` is the directory in which you placed KHT's source code.
-
-Use the files in the `<kht-dir>/cpp/example` directory as examples of how to configure and call the reference implementation of the KHT from your C++ program. For instance, after installation of the KHT library, CMake will find KHT using the command `find_package(KHT)` (see the [`<kht-dir>/cpp/example/CMakeLists.txt`](cpp/example/CMakeLists.txt) file and the [CMake documentation](https://cmake.org/cmake/help/latest/command/find_package.html) for details). Also, you will be able to use the `KHT_INCLUDE_DIRS` variable in the `CMakeList.txt` file of your program while defining the include directories of your C++ project or targets. In your source code, you have to use the `#include <kht/kht.hpp>` directive to include the contents of the standard header file and then call the `kht` procedure (see the [`<kht-dir>/cpp/example/kht_example.cpp`](cpp/example/kht_example.cpp) file).
-
-Similarly, you will find examples of how to use the KHT library with Python and MATLAB in, respectively, the [`<kht-dir>/python/example`](python/example) and [`<kht-dir>/matlab/example`](matlab/example) directories.
-
-## 4. Related Project
-
-Please, visit the [project's page](http://www.ic.uff.br/~laffernandes/projects/kht) to find a list of related projects.
-
-## 5. License
-
-This software is licensed under the GNU General Public License v3.0. See the [`LICENSE`](LICENSE) file for details.
-
-## 6. Releases
-
-Version 2.0.0
-
-- *REPOSITORY*: The project moved from [SourceForge](https://sourceforge.net/projects/khtsandbox) to [GitHub](https://github.com/laffernandes/kht).
-- *BUILD SYSTEM*: CMake becomes the default build system of KHT. Platform-specific solutions will not be provided anymore.
-- *PYTHON*: The Python back-end was included.
-
-Version 1.0.4
-
-- *BUG FIX*: In the `next()` function of `linking.cpp` file, there were no protections against accessing pixels outside the image limits. The author would like to thank Timo Knuutile for pointing out this problem.
-
-Version 1.0.3
-
-- *UPDATE*: The `kht_compile.m` file was ported to MATLAB R2011b, and a Microsoft Visual Studio 2010 project was included.
-
-Version 1.0.2
-
-- *BUG FIX*: In line 177 of peak_detection.cpp file, the function `compare_bins` was being forced to assume a non-standard calling convention when passed as an argument to `std::qsort()` function, preventing its compilation on Linux. The problem was fixed. The authors would like to thank Laurens Leeuwis for pointing out this problem.
-
-Version 1.0.1
-
-- *BUG FIX*: During the initialization of the accumulator, the last item of the lookup table defining the discrete `theta` values was not initialized. In such a case, the value should be `180-delta` degrees. As a result, detected lines having `theta = 180-delta` were getting a random angular value. The authors would like to thank Dave Wood for pointing out this problem.
-
-Version 1.0.0
-
-- *NEW*: Everything is new.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -54,6 +54,9 @@ set_target_properties(kht PROPERTIES POSITION_INDEPENDENT_CODE ON PUBLIC_HEADER 
 
 include(GNUInstallDirs)
 
+# Add build of pybind11 wrapper
+add_subdirectory(lsst/kht)
+
 install(TARGETS kht
   ARCHIVE DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/kht"
   PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_PREFIX}/include/kht"

--- a/cpp/include/kht/kht.hpp
+++ b/cpp/include/kht/kht.hpp
@@ -116,7 +116,7 @@ namespace kht {
     * It is important to notice that the linking procedure implemented by the kht()
     * function destroys the original image.
     */
-    void run_kht(ListOfLines &result, std::uint8_t *binary_image, std::size_t image_width, std::size_t image_height, std::int32_t cluster_min_size = 10, std::double_t cluster_min_deviation = 2.0, std::double_t delta = 0.5, std::double_t kernel_min_height = 0.002, std::double_t n_sigmas = 2.0);
+    void run_kht(ListOfLines &result, std::uint8_t *binary_image, std::size_t image_width, std::size_t image_height, std::int32_t cluster_min_size = 10, std::double_t cluster_min_deviation = 2.0, std::double_t delta = 0.5, std::double_t kernel_min_height = 0.002, std::double_t n_sigmas = 2.0, std::double_t abs_kernel_min_height = 0);
 
     // The private namespace of the KHT library (don't touch it!).
     namespace detail {
@@ -416,6 +416,8 @@ namespace kht {
 
         // Performs the proposed Hough transform voting scheme.
         void voting(Accumulator &accumulator, ListOfClusters const &clusters, std::double_t kernel_min_height, std::double_t n_sigmas);
+
+        void voting(Accumulator &accumulator, ListOfClusters const &clusters, std::double_t kernel_min_height, std::double_t n_sigmas, std::double_t abs_kernel_min_height);
 
     }
 

--- a/cpp/lsst/kht/CMakeLists.txt
+++ b/cpp/lsst/kht/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.14)
+project(kht)
+
+find_package(pybind11 REQUIRED)
+
+include_directories("../../include/kht/")
+include_directories($ENV{EIGEN_DIR}/include/eigen3)
+
+set(PYTHON_MODULE_EXTENSION ".so")
+
+pybind11_add_module(pykht kht.cc)
+target_link_libraries(pykht PUBLIC kht)
+configure_file(khtContinued.py khtContinued.py COPYONLY)
+configure_file(__init__.py __init__.py COPYONLY)
+

--- a/cpp/lsst/kht/__init__.py
+++ b/cpp/lsst/kht/__init__.py
@@ -1,0 +1,2 @@
+from .khtContinued import *
+

--- a/cpp/lsst/kht/kht.cc
+++ b/cpp/lsst/kht/kht.cc
@@ -1,0 +1,38 @@
+
+
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+
+#include "ndarray/pybind11.h"
+#include <tuple>
+
+#include "kht.hpp"
+
+namespace kht {
+namespace py = pybind11;
+using PyLine = py::class_<Line, std::shared_ptr<Line>>;
+
+
+PYBIND11_MODULE(pykht, mod) {
+
+  PyLine cls(mod, "Line");
+  cls.def(py::init<double, double>());
+  cls.def_readwrite("rho", &Line::rho);
+  cls.def_readwrite("theta", &Line::theta);
+
+  mod.def("find_satellites",
+          [](ndarray::Array<bool, 2, 2> & binary_image, std::size_t image_width, std::size_t image_height, std::int32_t cluster_min_size, std::double_t cluster_min_deviation, std::double_t delta, std::double_t kernel_min_height, std::double_t n_sigmas, std::double_t abs_kernel_min_height) -> std::vector<Line> {
+            static ListOfLines lines;
+            run_kht(lines, reinterpret_cast<std::uint8_t *>(binary_image.getData()), image_width, image_height, cluster_min_size, cluster_min_deviation, delta, kernel_min_height, n_sigmas, abs_kernel_min_height);
+            
+            std::vector<Line> output_lines;
+            output_lines.reserve(lines.size());
+            for (size_t i=0;  i< lines.size(); i++){
+              output_lines.push_back(lines[i]);
+            }
+            return output_lines;
+          }
+
+);
+}
+}

--- a/cpp/lsst/kht/khtContinued.py
+++ b/cpp/lsst/kht/khtContinued.py
@@ -1,0 +1,26 @@
+
+import numpy as np
+from .pykht import find_satellites as fs
+
+
+def find_satellites(image, cluster_min_size,
+                    cluster_min_deviation, delta, kernel_min_height, n_sigmas, abs_kernel_min_height):
+
+    im_copy = np.copy(image).astype(bool)
+    image_height, image_width = image.shape
+    image_height = int(image_height)
+    image_width = int(image_width)
+
+    fit_im = np.require(im_copy, bool, ['CONTIGUOUS', 'ALIGNED'])
+    lines = fs(fit_im, image_width, image_height, cluster_min_size, cluster_min_deviation,
+               delta, kernel_min_height, n_sigmas, abs_kernel_min_height)
+
+    rhos, thetas = [], []
+    for line in lines:
+        rhos.append(line.rho)
+        thetas.append(line.theta)
+    res = [rhos, thetas]
+    result = np.core.records.fromarrays(res, dtype=[('rho', float),
+                                                    ('theta', float),
+                                                    ])
+    return result

--- a/cpp/source/kht.cpp
+++ b/cpp/source/kht.cpp
@@ -36,7 +36,7 @@
 namespace kht {
 
     // Kernel-based Hough transform (KHT) for detecting straight lines in images.
-    void run_kht(ListOfLines &result, std::uint8_t *binary_image, std::size_t image_width, std::size_t image_height, std::int32_t cluster_min_size, std::double_t cluster_min_deviation, std::double_t delta, std::double_t kernel_min_height, std::double_t n_sigmas) {
+    void run_kht(ListOfLines &result, std::uint8_t *binary_image, std::size_t image_width, std::size_t image_height, std::int32_t cluster_min_size, std::double_t cluster_min_deviation, std::double_t delta, std::double_t kernel_min_height, std::double_t n_sigmas, std::double_t abs_kernel_min_height) {
         using namespace detail;
         
         static ListOfChains chains;
@@ -50,10 +50,9 @@ namespace kht {
 
         // Perform the proposed Hough transform voting scheme.
         accumulator.init(image_width, image_height, delta);
-        voting(accumulator, clusters, kernel_min_height, n_sigmas);
+        voting(accumulator, clusters, kernel_min_height, n_sigmas, abs_kernel_min_height);
 
         // Retrieve the most significant straight lines from the resulting voting map.
         peak_detection(result, accumulator);
     }
-
 }

--- a/cpp/source/voting.cpp
+++ b/cpp/source/voting.cpp
@@ -190,7 +190,7 @@ namespace kht {
         }
 
         // Performs the proposed Hough transform voting scheme.
-        void voting(Accumulator &accumulator, ListOfClusters const &clusters, std::double_t kernel_min_height, std::double_t n_sigmas) {
+        void voting(Accumulator &accumulator, ListOfClusters const &clusters, std::double_t kernel_min_height, std::double_t n_sigmas, std::double_t abs_kernel_min_height) {
             /* Leandro A. F. Fernandes, Manuel M. Oliveira
             * Real-time line detection through an improved Hough transform voting scheme
             * Pattern Recognition (PR), Elsevier, 41:1, 2008, pp. 299-314.
@@ -304,13 +304,15 @@ namespace kht {
 
             std::size_t i = 0;
             for (std::size_t k = 0, end = used_kernels.size(); k != end; ++k) {
-                if ((used_kernels[k]->height * norm) >= kernel_min_height) {
-                    if (i != k) {
-                        Kernel *temp = used_kernels[i];
-                        used_kernels[i] = used_kernels[k];
-                        used_kernels[k] = temp;
+                if (used_kernels[k]->height >= abs_kernel_min_height) {
+                    if ((used_kernels[k]->height * norm) >= kernel_min_height) {
+                        if (i != k) {
+                            Kernel *temp = used_kernels[i];
+                            used_kernels[i] = used_kernels[k];
+                            used_kernels[k] = temp;
+                        }
+                        i++;
                     }
-                    i++;
                 }
             }
             used_kernels.resize(i);
@@ -337,7 +339,11 @@ namespace kht {
                 vote(accumulator, kernel->rho_index - 1, kernel->theta_index - 1, -delta, -delta, -1, -1, kernel->lambda[0], kernel->lambda[3], kernel->lambda[1], kernels_scale);
             }
         }
-
+        
+        void voting(Accumulator &accumulator, ListOfClusters const &clusters, std::double_t kernel_min_height, std::double_t n_sigmas) {
+            std::double_t abs_kernel_min_height = 0;
+            voting(accumulator, clusters, kernel_min_height, n_sigmas, abs_kernel_min_height);
+        }
     }
 
 }

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,0 +1,7 @@
+build() {
+cd cpp
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX ..
+cmake --build . --config Release
+}

--- a/ups/kht.table
+++ b/ups/kht.table
@@ -1,0 +1,3 @@
+setupRequired(eigen)
+
+envPrepend(PYTHONPATH, ${PRODUCT_DIR}/cpp/build)


### PR DESCRIPTION
This adds support for building with eups and adds a pybind11
python binding. Additionally, it adds an optional argument to
the run_kht function, allowing an absolute minimum value cut
on the kernel height, in addition to the already available cut
at a fraction of the maximum kernel height found.